### PR TITLE
Fixed a wording error in one of the BaseScript.lua

### DIFF
--- a/testing-guidance/workflow-tests/scripting/lua-scripting-tests.md
+++ b/testing-guidance/workflow-tests/scripting/lua-scripting-tests.md
@@ -230,7 +230,7 @@ function BaseScript:OnActivate()
 end
 
 --OnHeld is activated when an input is being held or applied constantly (as in the case of mouse movement)
-function PlayerScript:OnHeld(inputValue)
+function BaseScript:OnHeld(inputValue)
 	--Create a reference to the currently used input
 	local currentBusId = InputEventNotificationBus.GetCurrentBusId();
 	


### PR DESCRIPTION
**Change Summary:**
* Fixed one of the function names in the Area: Moving entity using Lua script -> BaseScript.lua.